### PR TITLE
fix: use proper url for full devdocs

### DIFF
--- a/lua/devdocs/docs.lua
+++ b/lua/devdocs/docs.lua
@@ -58,7 +58,7 @@ M.FetchDevdocsMetadata = function(onComplete)
   vim.system({
     'curl',
     '-s',
-    'https://documents.devdocs.io/docs.json',
+    'https://devdocs.io/docs.json',
     '-o',
     C.METADATA_FILE,
   }, { text = false }, function(res)


### PR DESCRIPTION
fixes #1 