### PR TITLE
Add windows support

### DIFF
--- a/lua/devdocs/init.lua
+++ b/lua/devdocs/init.lua
@@ -138,14 +138,14 @@ M.GetInstalledDocs = D.GetInstalledDocs
 
 --- Get filepaths of all documents for a doc
 --- @param doc string
---- @return [string] | nil
+--- @return string[] | nil
 M.GetDoc = function(doc)
   return D.GetDocFiles(doc)
 end
 
 --- Get directory for a doc
 --- @param doc string
---- @return [string] | nil
+--- @return string | nil
 M.GetDocDir = function(doc)
   return C.DOCS_DIR .. '/' .. doc
 end


### PR DESCRIPTION
The current plugin works fine in windows with the only exception that is the creation of directories with the unix command `mkdir` which causes errors when installing a documentation. This happens because windows does not have a mkdir binary.

This PR addresses the issue by abstracting the directory creation into a module function `Mkdir`.
The function will call the appropriate native command to create directories under linux/mac using `mkdir` and powershell's cmdlet `New-Item` on windows.

--

## Additional changes

### Double //

I observed during my tests that `paths` could be empty in the snippet below.

```lua
local dir = C.DOCS_DIR .. '/' .. slug ..  '/' .. table.concat(parts, '/') -- if empty
local outputFile = dir .. '/' .. filename  -- causes double `//` before filename
```

I added a check to prevent adding a double `//`.

### Error with vim.notify

The call to vim.notify inside `ExtractDocs` gave me an error for being called inside a callback. I wrapped it it in vim.schedule to prevent this.

### Changes in type annotations

I corrected some types from the annotation of some functions as I saw warnings when setting up the plugin.
